### PR TITLE
Move ncp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "front-matter": "^4.0.2",
+    "ncp": "^2.0.0",
     "posthtml-cli": "^0.7.5",
     "posthtml-md2html": "^0.0.2",
     "posthtml-xm-import": "^0.1.1",
@@ -33,7 +34,6 @@
   },
   "devDependencies": {
     "highlight.js": "^10.1.2",
-    "ncp": "^2.0.0",
     "snapshot-dir": "^1.1.2",
     "source-map-support": "^0.5.19"
   }


### PR DESCRIPTION
When running `xm build` (without `htmlOnly` flag) it fails because `ncp` is not found:

```
$ yarn xm build

  ₪ xm  extensible static HTML

internal/modules/cjs/loader.js:800
    throw err;
    ^

Error: Cannot find module 'ncp'
```

Tested with `yalc` locally and this seemed to fix it.