### PR TITLE
Add support for custom port

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ if (cmd === "help" || args.some((a) => a === "-h" || a === "--help")) {
 }
 
 const isDev = cmd === "dev";
-const port = 5000;
+const portOptionIndex = args.findIndex((a) => a === "-p" || a === "--port")
+const port = (~portOptionIndex && args[portOptionIndex + 1]) || 5000
 
 const rootDir = args.reduce((rootDir, option, index) => {
   if (["-r", "--root"].includes(option) && args[index + 1]) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ if (cmd === "help" || args.some((a) => a === "-h" || a === "--help")) {
 
 const isDev = cmd === "dev";
 const portOptionIndex = args.findIndex((a) => a === "-p" || a === "--port")
-const port = (~portOptionIndex && args[portOptionIndex + 1]) || 5000
+let port = 5000
+if (~portOptionIndex && args[portOptionIndex + 1]) {
+  port = args[portOptionIndex + 1];
+  args.splice(portOptionIndex, 2);
+}
 
 const rootDir = args.reduce((rootDir, option, index) => {
   if (["-r", "--root"].includes(option) && args[index + 1]) {

--- a/utils.js
+++ b/utils.js
@@ -88,7 +88,13 @@ module.exports.help = function help() {
     }
   );
   log(
-    `     <b>--htmlOnly</b>   Compiles and copies only the built HTML files\n`,
+    `     <b>--htmlOnly</b>   Compiles and copies only the built HTML files`,
+    {
+      prefix: false,
+    }
+  );
+  log(
+    `     <b>--port</b>       Port used for the dev server\n`,
     {
       prefix: false,
     }

--- a/utils.js
+++ b/utils.js
@@ -94,7 +94,7 @@ module.exports.help = function help() {
     }
   );
   log(
-    `     <b>--port</b>       Port used for the dev server\n`,
+    `     <b>--port</b>       Port used for the dev server (default: 5000)\n`,
     {
       prefix: false,
     }


### PR DESCRIPTION
Adds `-p` or `--port` to specify a custom dev server port, with a fallback to 5000.