### PR TITLE
Fix missing footer in compiled slot/fill example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ HTML files can define `slot` elements with an attribute `name`. slots can be fil
   <h1>About</h1>
   <p>welcome</p>
 </main>
+<footer>Unique to this page</footer>
 ```
 
 You can also define a special unnamed `slot` that will be filled with the `import` children that are not `fill` tags:

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,7 +173,8 @@ Options:
 &lt;main&gt;
   &lt;h1&gt;About&lt;/h1&gt;
   &lt;p&gt;welcome&lt;/p&gt;
-&lt;/main&gt;</code></pre>
+&lt;/main&gt;
+&lt;footer&gt;Unique to this page&lt;/footer&gt;</code></pre>
 <p>You can also define a special unnamed <code>slot</code> that will be filled with the <code>import</code> children that are not <code>fill</code> tags:</p>
 <pre><code class="language-html">&lt;!-- base.html --&gt;
 


### PR DESCRIPTION
Hopefully this is correct - I was just reading through the docs and this was a bit confusing, I assume the `<footer>` is supposed to stay there since it's outside the `<import>` tag.